### PR TITLE
Issue #76: Bump required "catalog" version to 0.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "~7.0.0",
-        "lizards-and-pumpkins/catalog": "~0.14.0-alpha"
+        "lizards-and-pumpkins/catalog": "~0.15.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.6.2",


### PR DESCRIPTION
Closes #76.