### PR TITLE
Issue #80: Fix deadlock by not processing messages while the lock is held

### DIFF
--- a/src/FileQueue.php
+++ b/src/FileQueue.php
@@ -66,8 +66,9 @@ class FileQueue implements Queue, Clearable
         while ($numberOfMessagesToConsume > 0) {
             $this->retrieveLock();
             if ($this->isReadyForNext()) {
-                $messageReceiver->receive($this->next());
+                $message = $this->next();
                 $this->releaseLock();
+                $messageReceiver->receive($message);
                 $numberOfMessagesToConsume--;
             } else {
                 $this->releaseLock();


### PR DESCRIPTION
This resolves the issues in the dev-VM with catalog 0.15.0

This needs to be released as a patch level update for the filesystem queue library asap (e.g. 0.13.1).
Then all we need to do is update the minimum version in the sample-project to point to 0.13.1, too, and we should be all good again.