### PR TITLE
#94: Bump required "catalog" version to 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "~7.0.0",
-        "lizards-and-pumpkins/catalog": "~2.0.0"
+        "lizards-and-pumpkins/catalog": "~3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Closes #94.